### PR TITLE
I've aligned the iOS ViewModel setup with Android using Koin and adde…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ navigation = "2.7.0-alpha07"
 lifecycleViewModel = "2.8.7"
 kmpNativeCoroutines = "1.0.0-ALPHA-37"
 datastore = "1.1.2"
+mockk = "1.13.10"
+kotlinx-coroutines-test = "1.8.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -50,6 +52,8 @@ koin-composeVM = { module = "io.insert-koin:koin-compose-viewmodel", version.ref
 navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+mockk-common = { module = "io.mockk:mockk-common", version.ref = "mockk" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,25 +1,83 @@
 import SwiftUI
 import Shared
+import KMPNativeCoroutinesAsync // Import for StateFlow observation
 
+// Wrapper class to make HomeViewModel usable with @StateObject/@ObservedObject
+class HomeViewModelWrapper: ObservableObject {
+    // The Koin-managed instance of HomeViewModel
+    // Accessed via the ViewModelProvider object defined in KoinIOS.kt
+    // Note: Kotlin's `object ViewModelProvider` is accessed as `ViewModelProvider.shared` in Swift.
+    private let koinViewModel: HomeViewModel = ViewModelProvider.shared.homeViewModel
+
+    // Published property to mirror HomeViewModel's emailId StateFlow
+    @Published var email: String = ""
+    
+    // Cancellable for observing the StateFlow
+    private var cancellable: Any?
+
+    init() {
+        // Initial fetch of email
+        koinViewModel.getEmail()
+        
+        // Observe the emailId StateFlow from HomeViewModel
+        // Using KMPNativeCoroutinesAsync to bridge Kotlin's Flow to Combine's Publisher
+        // The `koinViewModel.emailId` is a StateFlow<String>
+        // `createPublisher(for: koinViewModel.emailId)` converts it to a Combine Publisher
+        cancellable = createPublisher(for: koinViewModel.emailId)
+            .receive(on: DispatchQueue.main) // Ensure UI updates are on the main thread
+            .sink(receiveCompletion: { completion in
+                if case let .failure(error) = completion {
+                    print("Error observing emailId: \(error)")
+                }
+            }, receiveValue: { [weak self] newEmail in
+                self?.email = newEmail
+            })
+    }
+
+    // Expose methods from HomeViewModel
+    func onSaveUser() {
+        koinViewModel.onSaveUser()
+    }
+
+    func getEmail() {
+        koinViewModel.getEmail() // This will trigger the StateFlow to update, and the sink will update @Published var
+    }
+    
+    // Method to update the email in the ViewModel
+    // This corresponds to onEmailIdChange in the Kotlin ViewModel
+    func onEmailChange(newEmail: String) {
+        koinViewModel.onEmailIdChange(emailId: newEmail)
+    }
+    
+    deinit {
+        cancellable?.cancel()
+    }
+}
 
 struct AppView: View {
-    private var viewModel = HomeViewModel()
+    // Use @StateObject for iOS 14+ to own the HomeViewModelWrapper lifecycle
+    @StateObject private var wrapper = HomeViewModelWrapper()
     
-    @State private var emailId: String = ""
-
     var body: some View {
         VStack {
             Spacer().frame(height: 16)
             
-            TextField("Email", text: $emailId)
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-                .padding(.horizontal)
+            // TextField binds to the wrapper's @Published email property
+            // And calls onEmailChange when the text changes
+            TextField("Email", text: Binding(
+                get: { wrapper.email },
+                set: { newEmail in
+                    wrapper.email = newEmail // Update local published property
+                    wrapper.onEmailChange(newEmail: newEmail) // Propagate change to KMP ViewModel
+                }
+            ))
+            .textFieldStyle(RoundedBorderTextFieldStyle())
+            .padding(.horizontal)
             
             Spacer().frame(height: 16)
             
             Button(action: {
-                viewModel.onSaveUser()
-            
+                wrapper.onSaveUser()
             }) {
                 Text("Save")
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -30,17 +88,28 @@ struct AppView: View {
             }
             .padding(.horizontal)
             
+            // Button to explicitly refresh email (demonstrates getEmail)
+            Button(action: {
+                wrapper.getEmail()
+            }) {
+                Text("Refresh Email from DB")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding()
+                    .background(Color.green)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+            }
+            .padding(.horizontal)
+            
             Spacer()
         }
         .onAppear {
-            viewModel.getEmail()
-        
-            print("Email: $viewModel.emailId")
+            // Initial data load is handled by the wrapper's init
+            // wrapper.getEmail() // Can be called here if not in init, but init is better for initial setup
         }
         .padding()
     }
 }
-
 
 struct AppView_Previews: PreviewProvider {
     static var previews: some View {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,7 +1,15 @@
 import SwiftUI
+import Shared // Import the shared module
 
 @main
 struct iOSApp: App {
+    init() {
+        // Call the initKoin function from the shared module
+        // The KoinIOS.kt file contains the top-level function `initKoin()`
+        // which is exposed to Swift as `KoinIOSKt.doInitKoin()`
+        KoinIOSKt.doInitKoin()
+    }
+
     var body: some Scene {
         WindowGroup {
             AppView()

--- a/iosApp/iosAppTests/HomeViewModelWrapperTests.swift
+++ b/iosApp/iosAppTests/HomeViewModelWrapperTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import iosApp // Or your app's module name
+import Shared
+
+class HomeViewModelWrapperTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // It's crucial that Koin is initialized before HomeViewModelWrapper tries to use it.
+        // If not initialized globally for tests, do it here.
+        // This assumes KoinIOSKt.doInitKoin() sets up the *actual* Koin modules.
+        // For more isolated tests, you'd set up Koin with test-specific (mocked) modules.
+        KoinIOSKt.doInitKoin() 
+    }
+
+    func testHomeViewModelWrapperInitialization() {
+        let wrapper = HomeViewModelWrapper()
+        XCTAssertNotNil(wrapper, "HomeViewModelWrapper should initialize successfully.")
+        // Optionally, you could try calling a method if it doesn't have side effects
+        // or if Koin is set up with mocks for the underlying KMP ViewModel.
+        // For a smoke test, just initialization is often enough.
+        wrapper.getEmail() // Example of calling a method
+        XCTAssertNotNil(wrapper.email, "Email property should exist")
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -42,6 +42,13 @@ kotlin {
             implementation(libs.datastore)
             implementation(libs.datastore.preferences)
         }
+        val iosMain by creating {
+            dependsOn(commonMain.get())
+            dependencies {
+                // Add Koin core dependency for iOS
+                api(libs.koin.core)
+            }
+        }
         androidMain.dependencies {
             implementation(libs.koin.android)
             implementation(libs.koin.androidx.compose)
@@ -49,6 +56,11 @@ kotlin {
             implementation(libs.lifecycle.viewmodel)
             implementation(libs.room.runtime.android)
 
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.mockk.common)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/shared/src/commonTest/kotlin/dev/muthuram/roomdatabase/presentation/HomeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/dev/muthuram/roomdatabase/presentation/HomeViewModelTest.kt
@@ -1,0 +1,103 @@
+package dev.muthuram.roomdatabase.presentation
+
+import dev.muthuram.roomdatabase.domain.model.User
+import dev.muthuram.roomdatabase.domain.usecase.GetUserUseCase
+import dev.muthuram.roomdatabase.domain.usecase.UpdateUserUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest : KoinTest {
+
+    private val getUserUseCase: GetUserUseCase by inject()
+    private val updateUserUseCase: UpdateUserUseCase by inject()
+    private lateinit var viewModel: HomeViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        startKoin {
+            modules(
+                module {
+                    single { mockk<GetUserUseCase>() }
+                    single { mockk<UpdateUserUseCase>(relaxed = true) }
+                }
+            )
+        }
+        // ViewModel is instantiated after Koin setup so it picks up the mocks
+        viewModel = HomeViewModel()
+    }
+
+    @Test
+    fun test_onEmailChange_updatesEmailStateFlow() = runTest(testDispatcher) {
+        val testEmail = "test@example.com"
+        viewModel.onEmailIdChange(testEmail)
+        assertEquals(testEmail, viewModel.emailId.first())
+    }
+
+    @Test
+    fun test_getEmail_updatesEmailStateFlow_fromUseCase() = runTest(testDispatcher) {
+        val expectedEmail = "usecase@example.com"
+        val userList = listOf(User(emailId = expectedEmail))
+        // Mock the behavior of GetUserUseCase
+        coEvery { getUserUseCase.invoke() } returns flowOf(userList)
+
+        viewModel.getEmail()
+        testDispatcher.scheduler.advanceUntilIdle() // Ensure coroutines and StateFlow updates complete
+
+        assertEquals(expectedEmail, viewModel.emailId.first())
+    }
+
+    @Test
+    fun test_getEmail_updatesEmailStateFlow_empty_fromUseCase() = runTest(testDispatcher) {
+        val expectedEmail = "" // Expect empty string if use case returns empty list
+        val userList = emptyList<User>()
+        coEvery { getUserUseCase.invoke() } returns flowOf(userList)
+
+        viewModel.getEmail()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(expectedEmail, viewModel.emailId.first())
+    }
+    
+    @Test
+    fun test_onSaveUser_callsUpdateUserUseCase() = runTest(testDispatcher) {
+        val emailToSave = "saveme@example.com"
+        viewModel.onEmailIdChange(emailToSave)
+        testDispatcher.scheduler.advanceUntilIdle() // Ensure StateFlow updates before saving
+
+        // updateUserUseCase is relaxed, but we can still verify calls
+        // No need for coEvery { updateUserUseCase.invoke(any()) } returns Unit due to relaxed = true
+
+        viewModel.onSaveUser()
+        testDispatcher.scheduler.advanceUntilIdle() // Ensure the save coroutine completes
+
+        coVerify { updateUserUseCase.invoke(User(emailId = emailToSave)) }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+        Dispatchers.resetMain()
+    }
+}

--- a/shared/src/commonTest/kotlin/dev/muthuram/roomdatabase/presentation/SavedTextViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/dev/muthuram/roomdatabase/presentation/SavedTextViewModelTest.kt
@@ -1,0 +1,74 @@
+package dev.muthuram.roomdatabase.presentation
+
+import dev.muthuram.roomdatabase.data.db.UserDao
+import dev.muthuram.roomdatabase.domain.model.User
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SavedTextViewModelTest {
+
+    private lateinit var userDao: UserDao
+    private lateinit var viewModel: SavedTextViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        userDao = mockk()
+        viewModel = SavedTextViewModel(userDao)
+    }
+
+    @Test
+    fun test_getEmail_updatesEmailIdState_fromUserDao() = runTest(testDispatcher) {
+        val expectedEmail = "dao@example.com"
+        val userList = listOf(User(emailId = expectedEmail))
+        coEvery { userDao.getAllPeople() } returns flowOf(userList)
+
+        viewModel.getEmail()
+        testDispatcher.scheduler.advanceUntilIdle() // Ensure coroutines and StateFlow updates complete
+
+        assertEquals(expectedEmail, viewModel.emailId.value)
+    }
+
+    @Test
+    fun test_getEmail_updatesEmailIdState_empty_fromUserDao() = runTest(testDispatcher) {
+        val expectedEmail = "" // Expect empty string if DAO returns empty list
+        val userList = emptyList<User>()
+        coEvery { userDao.getAllPeople() } returns flowOf(userList)
+
+        viewModel.getEmail()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(expectedEmail, viewModel.emailId.value)
+    }
+    
+    @Test
+    fun test_getEmail_updatesEmailIdState_withNullFromUserDao() = runTest(testDispatcher) {
+        val expectedEmail = "" // Expect empty string if DAO returns null user
+        val userList = listOf(null) // Simulate a Flow that might emit nulls in a list, though Dao usually filters
+        coEvery { userDao.getAllPeople() } returns flowOf(userList.filterNotNull()) // getAllPeople likely returns Flow<List<User>>
+
+        viewModel.getEmail()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(expectedEmail, viewModel.emailId.value)
+    }
+
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}

--- a/shared/src/iosMain/kotlin/dev/muthuram/roomdatabase/di/KoinIOS.kt
+++ b/shared/src/iosMain/kotlin/dev/muthuram/roomdatabase/di/KoinIOS.kt
@@ -1,0 +1,24 @@
+package dev.muthuram.roomdatabase.di
+
+import dev.muthuram.roomdatabase.presentation.HomeViewModel
+import dev.muthuram.roomdatabase.presentation.SavedTextViewModel
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+// Actual platform-specific module for iOS.
+actual fun platformModule(): Module = module { }
+
+// iOS-specific Koin initialization function.
+fun initKoin() {
+    dev.muthuram.roomdatabase.di.initKoin {
+        // We can add iOS-specific Koin configuration here if needed.
+    }
+}
+
+// ViewModelProvider object to easily access ViewModels from Swift
+object ViewModelProvider : KoinComponent {
+    val homeViewModel: HomeViewModel by inject()
+    val savedTextViewModel: SavedTextViewModel by inject() // Added this as it's likely needed too
+}


### PR DESCRIPTION
Here's a summary of the key changes:
- I integrated Koin for dependency injection in the iOS application.
  - I added Koin dependencies to `shared/build.gradle.kts` for iOS targets.
  - I initialized Koin in `iOSApp.swift` using a helper from the shared module (`KoinIOS.kt`).
- I updated `ContentView.swift` to resolve `HomeViewModel` via Koin.
  - I introduced `HomeViewModelWrapper` as an `ObservableObject` to bridge the KMP ViewModel with SwiftUI.
  - I implemented `StateFlow` observation from Kotlin to Swift using `KMPNativeCoroutinesAsync`.
- I added common unit tests for `HomeViewModel` and `SavedTextViewModel`.
  - These are located in `shared/src/commonTest/kotlin`.
  - I utilized MockK for mocking dependencies and `kotlinx-coroutines-test` for testing coroutine-based logic.
- I added an iOS-specific smoke test for `HomeViewModelWrapper`.
  - This verifies that the wrapper can be initialized and its Koin dependencies are resolved in the test environment.

This brings the iOS ViewModel management closer to the Android pattern and improves test coverage for ViewModels across both platforms.